### PR TITLE
Adds dynamic row resizing based on bubble body text contents

### DIFF
--- a/platforms/apple/Borkle2/Borkle2/Base.lproj/Document.xib
+++ b/platforms/apple/Borkle2/Borkle2/Base.lproj/Document.xib
@@ -19,15 +19,15 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="xOd-HO-29H" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="133" y="235" width="507" height="413"/>
+            <rect key="contentRect" x="133" y="235" width="507" height="265"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1127"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="gIp-Ho-8D9">
-                <rect key="frame" x="0.0" y="0.0" width="507" height="413"/>
+                <rect key="frame" x="0.0" y="0.0" width="507" height="265"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M7b-Aj-8B8">
-                        <rect key="frame" x="9" y="366" width="84" height="32"/>
+                        <rect key="frame" x="9" y="218" width="84" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Splunge" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Zyy-G6-hMW">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -38,7 +38,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g30-cb-3Pv">
-                        <rect key="frame" x="101" y="366" width="64" height="32"/>
+                        <rect key="frame" x="101" y="218" width="64" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JBY-cy-M4G">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -49,7 +49,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Q8r-gj-C70">
-                        <rect key="frame" x="178" y="366" width="64" height="32"/>
+                        <rect key="frame" x="178" y="218" width="64" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Load" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="f4Q-od-vHl">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -60,7 +60,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v9K-VI-hyV">
-                        <rect key="frame" x="254" y="366" width="67" height="32"/>
+                        <rect key="frame" x="254" y="218" width="67" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Verfy" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="43V-Gt-Dyv">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -71,8 +71,8 @@
                         </connections>
                     </button>
                     <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wqy-1n-58a">
-                        <rect key="frame" x="66" y="327" width="421" height="21"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <rect key="frame" x="66" y="179" width="161" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Akm-a6-RTn">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -80,17 +80,17 @@
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6HB-wW-fts">
-                        <rect key="frame" x="66" y="296" width="421" height="21"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="5FQ-NG-rN5">
+                        <rect key="frame" x="66" y="78" width="161" height="91"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="5FQ-NG-rN5">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d6k-Qd-y3q">
-                        <rect key="frame" x="66" y="265" width="421" height="21"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <rect key="frame" x="66" y="48" width="161" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="bPT-Ym-8Gb">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,7 +98,7 @@
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="do3-It-vNK">
-                        <rect key="frame" x="33" y="330" width="27" height="16"/>
+                        <rect key="frame" x="33" y="182" width="27" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="title" id="I2B-tl-Ss5">
                             <font key="font" metaFont="system"/>
@@ -107,7 +107,7 @@
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pQX-uP-VJR">
-                        <rect key="frame" x="29" y="299" width="35" height="16"/>
+                        <rect key="frame" x="29" y="151" width="35" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="body" id="nyg-Qm-66L">
                             <font key="font" metaFont="system"/>
@@ -116,7 +116,7 @@
                         </textFieldCell>
                     </textField>
                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fdz-wI-GP1">
-                        <rect key="frame" x="29" y="268" width="31" height="16"/>
+                        <rect key="frame" x="29" y="51" width="31" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="tags" id="xKc-CV-cC8">
                             <font key="font" metaFont="system"/>
@@ -125,14 +125,14 @@
                         </textFieldCell>
                     </textField>
                     <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pqn-Tm-ccj">
-                        <rect key="frame" x="235" y="12" width="252" height="245"/>
+                        <rect key="frame" x="235" y="16" width="252" height="184"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <clipView key="contentView" id="B2l-ZH-VAB">
-                            <rect key="frame" x="1" y="1" width="250" height="243"/>
+                            <rect key="frame" x="1" y="1" width="250" height="182"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="automatic" viewBased="YES" id="6Kq-zp-tkx">
-                                    <rect key="frame" x="0.0" y="0.0" width="250" height="243"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="250" height="182"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="17" height="0.0"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -189,7 +189,7 @@
                         </scroller>
                     </scrollView>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xDs-V8-i3o">
-                        <rect key="frame" x="17" y="230" width="59" height="32"/>
+                        <rect key="frame" x="17" y="13" width="59" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="SDm-hY-gbe">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -199,12 +199,21 @@
                             <action selector="addItem:" target="-2" id="5Qr-ia-s9H"/>
                         </connections>
                     </button>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w8q-CC-e8E">
+                        <rect key="frame" x="233" y="202" width="54" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" lineBreakMode="clipping" title="Bubbles" id="fV1-HR-0X3">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-x8E"/>
             </connections>
-            <point key="canvasLocation" x="86.5" y="130.5"/>
+            <point key="canvasLocation" x="85.5" y="48.5"/>
         </window>
     </objects>
 </document>

--- a/platforms/apple/Borkle2/Borkle2/BubbleTableViewCell.swift
+++ b/platforms/apple/Borkle2/Borkle2/BubbleTableViewCell.swift
@@ -7,6 +7,15 @@ class BubbleTableViewCell: NSTableCellView {
     @IBOutlet var bodyField: NSTextField!
     @IBOutlet var tagsField: NSTextField!
 
+    override var backgroundStyle: NSView.BackgroundStyle {
+        get {
+            .emphasized
+        }
+        set { 
+            // nom
+        }
+    }
+
     var backgroundColor: NSColor {
         get {
             if let layerbg = layer?.backgroundColor {

--- a/platforms/apple/Borkle2/Borkle2/BubbleTableViewCell.xib
+++ b/platforms/apple/Borkle2/Borkle2/BubbleTableViewCell.xib
@@ -16,7 +16,7 @@
                     <rect key="frame" x="0.0" y="122" width="325" height="16"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Title" id="dN8-EF-Rr7">
-                        <font key="font" metaFont="systemBold"/>
+                        <font key="font" metaFont="systemBold" size="11"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -25,7 +25,7 @@
                     <rect key="frame" x="1" y="3" width="323" height="16"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Tags" id="KuZ-DI-3rX">
-                        <font key="font" metaFont="systemLight" size="13"/>
+                        <font key="font" metaFont="systemLight" size="11"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -34,7 +34,7 @@
                     <rect key="frame" x="12" y="20" width="312" height="100"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <textFieldCell key="cell" title="Body" id="d5p-lV-eS5">
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="system" size="10"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/platforms/apple/Borkle2/Borkle2/Document.swift
+++ b/platforms/apple/Borkle2/Borkle2/Document.swift
@@ -5,12 +5,6 @@ class Document: NSDocument {
 
     var soup: BubbleSoup = BubbleSoup()
 
-    @IBOutlet var tableView: NSTableView!
-
-    @IBOutlet var titleField: NSTextField!
-    @IBOutlet var bodyField: NSTextField!
-    @IBOutlet var tagsField: NSTextField!
-
     override init() {
         super.init()
         // Add your subclass-specific initialization here.
@@ -20,22 +14,11 @@ class Document: NSDocument {
         return true
     }
 
-    var awokenBefore = false
+    var windowController: DocumentWindowController!
 
-    /// Looks like the new 'improved' view-based tableview can trigger
-    /// awakeFromNib multiple times, one extra time for each tableview row
-    /// visible.  If you're doing one-time stuff in awakeFromNib, that's
-    /// kind of a problem. So hack around it by only running the one-time
-    /// work once.
-    var alreadyAwokenFromNib = false
-
-    override func awakeFromNib() {
-        if !alreadyAwokenFromNib {
-            let cellNib = NSNib(nibNamed: "BubbleTableViewCell", bundle: nil)
-            tableView.register(cellNib, forIdentifier: NSUserInterfaceItemIdentifier("bubbleColumn"))
-            
-            alreadyAwokenFromNib = true
-        }
+    override func makeWindowControllers() {
+        let windowController = DocumentWindowController(windowNibName: "Document")
+        addWindowController(windowController)
     }
 
     override var windowNibName: NSNib.Name? {
@@ -57,102 +40,5 @@ class Document: NSDocument {
         throw NSError(domain: NSOSStatusErrorDomain, code: unimpErr, userInfo: nil)
     }
 
-    @IBAction func splunge(_ sender: NSControl) {
-        
-        let bubbles =
-          [
-            Bubble(title: "Spoon", body: "Once upon a midnight dreary etc etc etc", tags: ["#first", "#splunge"], asset: nil),
-            Bubble(title: "Greeble Bork", body: "blah blah blah blah blah blah blah", tags: [], asset: nil),
-            Bubble(title: "Hoover fnord ekky", body: "Folks who are even a tiny bit crafty know the name Singer.  Back in the day, they had a nationwide chain of 175 stores selling the machines, fabrics, patterns, and associated goodies.  They needed automation", tags: ["#singer", "#system-ten", "#exhibit"], asset: nil),
-          ]
-
-        soup.bubbles = bubbles
-        tableView.reloadData()
-    }
-
-    @IBAction func saveYaml(_ sender: NSControl) {
-        Swift.print("SAVE")
-        let encoder = YAMLEncoder()
-        var options = encoder.options
-        options.indent = 2
-        options.width = -1
-        options.explicitStart = true
-        options.explicitEnd = true
-        options.sortKeys = true
-        encoder.options = options
-        let encodedYAML = try! encoder.encode(soup)
-        let data = encodedYAML.data(using: .utf8)!
-        let place = URL(fileURLWithPath: "/Users/markd/Downloads/blargh.yaml")
-        try! data.write(to: place)
-    }
- 
-    @IBAction func loadYaml(_ sender: NSControl) {
-        Swift.print("LOAD")
-        let place = URL(fileURLWithPath: "/Users/markd/Downloads/blargh.yaml")
-        let data = try! Data(contentsOf: place, options: [])
-        let decoder = YAMLDecoder()
-        let decoded = try! decoder.decode(BubbleSoup.self, from: data)
-        soup = decoded
-        tableView.reloadData()
-    }
-
-    @IBAction func verify(_ sender: NSControl) {
-        soup.verify()
-    }
-
-    @IBAction func addItem(_ sender: NSControl) {
-        let title = titleField.stringValue
-        let body = bodyField.stringValue
-        let tags = tagsField.stringValue.components(separatedBy: " ")
-
-        let bubble = Bubble(title: title, body: body, tags: tags, asset: nil)
-        soup.addBubble(bubble)
-
-        titleField.stringValue = ""
-        bodyField.stringValue = ""
-        tagsField.stringValue = ""
-
-        tableView.reloadData()
-    }
-}
-
-extension Document: NSTableViewDataSource, NSTableViewDelegate {
-    func numberOfRows(in tableView: NSTableView) -> Int {
-        soup.bubbles.count
-    }
-
-    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        90
-    }
-    
-    func tableView(_ tableView: NSTableView,
-                   viewFor tableColumn: NSTableColumn?,
-                   row: Int) -> NSView? {
-        guard let column = tableColumn else {
-            Swift.print("nil column")
-            return nil
-        }
-        
-        let bubble = soup.bubbles[row]
-
-        switch column.identifier.rawValue {
-        case "bubbleColumn":
-            let cell = tableView.makeView(
-                withIdentifier: column.identifier,
-                owner: self
-            ) as? BubbleTableViewCell
-            
-            cell?.titleField?.stringValue = "\(row)) " + (bubble.title ?? "----")
-            cell?.bodyField?.stringValue = bubble.body ?? "----"
-            cell?.tagsField?.stringValue = bubble.tags?.joined(separator: ", ") ?? "----"
-            cell?.backgroundColor = row.isMultiple(of: 2) ? Colors.bubbleListCellBackground_Even : Colors.bubbleListCellBackground_Odd
-            return cell
-            
-        default:
-            Swift.print("huh, identifier \(column.identifier)")
-            return nil
-        }
-    }
-    
 }
 

--- a/platforms/apple/Borkle2/Borkle2/DocumentWindowController.swift
+++ b/platforms/apple/Borkle2/Borkle2/DocumentWindowController.swift
@@ -1,0 +1,178 @@
+// DocumentWindowController: window controller for the main document
+
+import AppKit
+import Yams
+
+class DocumentWindowController: NSWindowController {
+
+    @IBOutlet var tableView: NSTableView!
+
+    @IBOutlet var titleField: NSTextField!
+    @IBOutlet var bodyField: NSTextField!
+    @IBOutlet var tagsField: NSTextField!
+   
+    override func windowDidLoad() {
+        super.windowDidLoad()
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    /// Looks like the new 'improved' view-based tableview can trigger
+    /// awakeFromNib multiple times, one extra time for each tableview row
+    /// visible.  If you're doing one-time stuff in awakeFromNib, that's
+    /// kind of a problem. So hack around it by only running the one-time
+    /// work once.
+    var alreadyAwokenFromNib = false
+
+    var soup: BubbleSoup {
+        (document as! Document).soup
+    }
+
+    override func awakeFromNib() {
+        if !alreadyAwokenFromNib {
+            let cellNib = NSNib(nibNamed: "BubbleTableViewCell", bundle: nil)
+            tableView.register(cellNib, forIdentifier: NSUserInterfaceItemIdentifier("bubbleColumn"))
+            setupObservers()
+            
+            alreadyAwokenFromNib = true
+        }
+    }
+
+    func setupObservers() {
+        NotificationCenter.default.addObserver(
+          self,
+          selector: #selector(windowDidResize),
+          name: NSWindow.didResizeNotification,
+          object: window
+        )
+    }
+
+    @objc func windowDidResize(_ notification: Notification) {
+        tableView.reloadData()
+    }
+
+    @IBAction func splunge(_ sender: NSControl) {
+        
+        let bubbles =
+          [
+            Bubble(title: "Spoon", body: "Once upon a midnight dreary etc etc etc", tags: ["#first", "#splunge"], asset: nil),
+            Bubble(title: "Greeble Bork", body: "blah blah blah blah blah blah blah", tags: [], asset: nil),
+            Bubble(title: "Hoover fnord ekky", body: "Folks who are even a tiny bit crafty know the name Singer.  Back in the day, they had a nationwide chain of 175 stores selling the machines, fabrics, patterns, and associated goodies.  They needed automation", tags: ["#singer", "#system-ten", "#exhibit"], asset: nil),
+          ]
+
+        soup.bubbles = bubbles
+        tableView.reloadData()
+    }
+
+    @IBAction func saveYaml(_ sender: NSControl) {
+        Swift.print("SAVE")
+        let encoder = YAMLEncoder()
+        var options = encoder.options
+        options.indent = 2
+        options.width = -1
+        options.explicitStart = true
+        options.explicitEnd = true
+        options.sortKeys = true
+        encoder.options = options
+        let encodedYAML = try! encoder.encode(soup)
+        let data = encodedYAML.data(using: .utf8)!
+        let place = URL(fileURLWithPath: "/Users/markd/Downloads/blargh.yaml")
+        try! data.write(to: place)
+    }
+ 
+    @IBAction func loadYaml(_ sender: NSControl) {
+        Swift.print("LOAD")
+        let place = URL(fileURLWithPath: "/Users/markd/Downloads/blargh.yaml")
+        let data = try! Data(contentsOf: place, options: [])
+        let decoder = YAMLDecoder()
+        let decoded = try! decoder.decode(BubbleSoup.self, from: data)
+        (document as! Document).soup = decoded
+        tableView.reloadData()
+        
+        Swift.print(soup)
+    }
+
+    @IBAction func verify(_ sender: NSControl) {
+        soup.verify()
+    }
+
+    @IBAction func addItem(_ sender: NSControl) {
+        let title = titleField.stringValue
+        let body = bodyField.stringValue
+        let tags = tagsField.stringValue.components(separatedBy: " ")
+
+        let bubble = Bubble(title: title, body: body, tags: tags, asset: nil)
+        soup.addBubble(bubble)
+
+        titleField.stringValue = ""
+        bodyField.stringValue = ""
+        tagsField.stringValue = ""
+
+        tableView.reloadData()
+    }
+}
+
+extension DocumentWindowController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        soup.bubbles.count
+    }
+
+    func heightFor(_ text: String?, width: CGFloat) -> CGFloat {
+        guard let text else { return 0 }
+
+        let textStorage = NSTextStorage.init(string: text, attributes: nil)
+        let margin: CGFloat = 5
+        let insetWidth = width - (margin * 2)
+        let size = CGSize(width: insetWidth, height: .infinity)
+        let textContainer = NSTextContainer.init(containerSize: size)
+        let layoutManager = NSLayoutManager()
+
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+        
+        // maybe need to add the font attribute textStorage.add
+        textContainer.lineFragmentPadding = 0.0
+        
+        _ = layoutManager.glyphRange(for: textContainer)
+        let height = layoutManager.usedRect(for: textContainer).height
+        return height
+    }
+    
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        let bubble = soup.bubbles[row]
+        let bodyHeight = heightFor(bubble.body, width: tableView.bounds.width)
+        let totalHeight = bodyHeight + 40
+        return totalHeight
+    }
+
+    func tableView(_ tableView: NSTableView,
+                   viewFor tableColumn: NSTableColumn?,
+                   row: Int) -> NSView? {
+        guard let column = tableColumn else {
+            Swift.print("nil column")
+            return nil
+        }
+        
+        let bubble = soup.bubbles[row]
+
+        switch column.identifier.rawValue {
+        case "bubbleColumn":
+            let cell = tableView.makeView(
+                withIdentifier: column.identifier,
+                owner: self
+            ) as? BubbleTableViewCell
+            
+            cell?.titleField?.stringValue = "\(row)) " + (bubble.title ?? "----")
+            cell?.bodyField?.stringValue = bubble.body ?? "----"
+            cell?.tagsField?.stringValue = bubble.tags?.joined(separator: ", ") ?? "----"
+            cell?.backgroundColor = row.isMultiple(of: 2) ? Colors.bubbleListCellBackground_Even : Colors.bubbleListCellBackground_Odd
+            return cell
+            
+        default:
+            Swift.print("huh, identifier \(column.identifier)")
+            return nil
+        }
+    }
+    
+}
+
+


### PR DESCRIPTION
Before, we didn't resize the tableview cells to snuggly up the size of the bubble's body contents

This PR sizes the string contents and bases the height of the cell on that.

To get this to happen on window resize, did some R3FAX()RING and moved a lot of document UI jazz into a window controller.

![bubbles-2](https://github.com/user-attachments/assets/8b8b9058-674d-492c-9b41-7a97bd985e11)
