### PR TITLE
Simplify bubble table filtering

### DIFF
--- a/platforms/apple/Borkle2/Borkle2/DocumentWindowController.swift
+++ b/platforms/apple/Borkle2/Borkle2/DocumentWindowController.swift
@@ -229,41 +229,38 @@ extension DocumentWindowController: NSTableViewDataSource, NSTableViewDelegate {
         if tableView == bubbleTableView { return }
         
         if tableView == tagTableView {
-            let row = tableView.selectedRow
-            // TODO: Really not liking doing composed searches like this.
-            if row < 0 {
-                if searchField.stringValue.count > 0 {
-                    soupAspect.predicate = { bubble in
-                        bubble.containsString(self.searchField.stringValue)
-                    }
-                } else {
-                    soupAspect.predicate = SoupAspect.identity
-                }
-            } else {
-                let tag = soup.allTags[row]
-                if searchField.stringValue.count > 0 {
-                    // filtering text *and* tags.
-                    soupAspect.predicate = { bubble in
-                        bubble.tagsContainsString(tag) && bubble.containsString(self.searchField.stringValue)
-                    }
-                } else {
-                    // just filter tags
-                    soupAspect.predicate = { bubble in
-                        bubble.tagsContainsString(tag)
-                    }
-                }
-            }
+            updateAspect() 
             bubbleTableView.reloadData()
         }
     }
 }
 
 extension DocumentWindowController: NSSearchFieldDelegate {
+    func updateAspect() {
+        soupAspect.reset()
+        if searchField.stringValue.count > 0 {
+            soupAspect.addPredicate { bubble in
+                bubble.containsString(self.searchField.stringValue)
+            }
+        }
+
+        let row = tagTableView.selectedRow
+        if row >= 0 {
+            let tag = soup.allTags[row]
+            
+            soupAspect.addPredicate { bubble in
+                bubble.tagsContainsString(tag)
+            }
+        }
+
+        bubbleTableView.reloadData()
+    }
+
     func searchFieldDidStartSearching(_ searchField: NSSearchField) {
     }
 
     func searchFieldDidEndSearching(_ searchField: NSSearchField) {
-        soupAspect.predicate = SoupAspect.identity
+        updateAspect()
     }
 
     // Thought I would use searchFieldDidStart/EndSearching, but there's a weird timeout,
@@ -271,18 +268,7 @@ extension DocumentWindowController: NSSearchFieldDelegate {
     // didStartSearching. Given how terrible the iOS SearchField class is, I'm not too sanguine
     // on how much of the search field's specific features outside of this I'll use.
     func controlTextDidChange(_ notification: Notification) {
-        defer {
-            bubbleTableView.reloadData()
-        }
-
-        guard self.searchField.stringValue.count > 0 else {
-            soupAspect.predicate = SoupAspect.identity
-            return
-        }
-        // TODO: honor tag filtering too
-        soupAspect.predicate = { bubble in 
-            bubble.containsString(self.searchField.stringValue)
-        }
+        updateAspect()
     }
 }
 

--- a/platforms/apple/Borkle2/Borkle2/SoupAspect.swift
+++ b/platforms/apple/Borkle2/Borkle2/SoupAspect.swift
@@ -9,7 +9,7 @@ class SoupAspect {
     typealias BubbleFilter = (Bubble) -> Bool
 
     let baseSoup: BubbleSoup
-    var predicate: BubbleFilter = { _ in true } {
+    private var predicates: [BubbleFilter] = [] {
         didSet {
             refilter()
         }
@@ -24,11 +24,29 @@ class SoupAspect {
         refilter()
     }
 
-    func refilter() {
-        let filteredIndicies = baseSoup.bubbles.indices.filter {
-            predicate(baseSoup.bubbles[$0])
-        }
-        indices = filteredIndicies
+    func reset() {
+        predicates = []
+        refilter() // lazy eval this when getting indices?
     }
-    
+
+    func addPredicate(_ predicate: @escaping BubbleFilter) {
+        predicates.append(predicate)
+        refilter() // lazy eval this when getting indices?
+    }
+
+    func refilter() {
+         if predicates.count == 0 {
+            // no predicates == all the things
+            indices = Array(baseSoup.bubbles.indices)
+        } else {
+            // otherwise, all must pass for the bubble to survive
+            let filteredIndicies = baseSoup.bubbles.indices.filter {
+                for predicate in predicates {
+                    if predicate(baseSoup.bubbles[$0]) == false { return false }
+                }
+                return true
+            }
+            indices = filteredIndicies
+        }
+    }
 }


### PR DESCRIPTION
Before, filtering the bubbles by both text and tag was a last-minute "we need this" for the last PR.  it's a mess and doesn't really work.

This PR cleans things up:
* Adds multiple predicates to SoupAspect - all of them must be satisfied before the bubble is displayed. (no predicates means that everything is shown)
* Updates the aspect with predicates when the search text changes and when the tableview selection changes.