### PR TITLE
Adds export utility

### DIFF
--- a/platforms/apple/Borkle2/Borkle2.xcodeproj/project.pbxproj
+++ b/platforms/apple/Borkle2/Borkle2.xcodeproj/project.pbxproj
@@ -61,6 +61,16 @@
 			);
 			target = 7D73FF132F2A755800590330 /* borkle1conv */;
 		};
+		7D7CF5FF2F2EEDF300119BF9 /* Exceptions for "Borkle2" folder in "borklekrunch" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Bubble.swift,
+				BubbleSoup.swift,
+				CGUtilities.swift,
+				Scene.swift,
+			);
+			target = 7D7CF5F22F2EE9D300119BF9 /* borklekrunch */;
+		};
 		7DE0B5462EECC49B00BDEB94 /* Exceptions for "Borkle2" folder in "Borkle2" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -86,6 +96,7 @@
 			exceptions = (
 				7DE0B5462EECC49B00BDEB94 /* Exceptions for "Borkle2" folder in "Borkle2" target */,
 				7D73FF202F2A766500590330 /* Exceptions for "Borkle2" folder in "borkle1conv" target */,
+				7D7CF5FF2F2EEDF300119BF9 /* Exceptions for "Borkle2" folder in "borklekrunch" target */,
 			);
 			path = Borkle2;
 			sourceTree = "<group>";

--- a/platforms/apple/Borkle2/Borkle2.xcodeproj/project.pbxproj
+++ b/platforms/apple/Borkle2/Borkle2.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7D73FF222F2A89E500590330 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 7D73FF212F2A89E500590330 /* Yams */; };
+		7D7CF5FB2F2EEB2400119BF9 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 7D7CF5FA2F2EEB2400119BF9 /* Yams */; };
 		7DE0B5702EECFC2E00BDEB94 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 7DE0B56F2EECFC2E00BDEB94 /* Yams */; };
 /* End PBXBuildFile section */
 
@@ -31,10 +32,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		7D7CF5F12F2EE9D300119BF9 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		7D73FF142F2A755800590330 /* borkle1conv */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = borkle1conv; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D7CF5F32F2EE9D300119BF9 /* borklekrunch */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = borklekrunch; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DE0B51F2EECC49A00BDEB94 /* Borkle2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Borkle2.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DE0B5342EECC49B00BDEB94 /* Borkle2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Borkle2Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -65,6 +76,11 @@
 			path = borkle1conv;
 			sourceTree = "<group>";
 		};
+		7D7CF5F42F2EE9D300119BF9 /* borklekrunch */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = borklekrunch;
+			sourceTree = "<group>";
+		};
 		7DE0B5212EECC49A00BDEB94 /* Borkle2 */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -87,6 +103,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				7D73FF222F2A89E500590330 /* Yams in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7D7CF5F02F2EE9D300119BF9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7D7CF5FB2F2EEB2400119BF9 /* Yams in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,6 +138,7 @@
 				7DE0B5212EECC49A00BDEB94 /* Borkle2 */,
 				7DE0B5372EECC49B00BDEB94 /* Borkle2Tests */,
 				7D73FF152F2A755800590330 /* borkle1conv */,
+				7D7CF5F42F2EE9D300119BF9 /* borklekrunch */,
 				7DE0B56E2EECFC2E00BDEB94 /* Frameworks */,
 				7DE0B5202EECC49A00BDEB94 /* Products */,
 			);
@@ -125,6 +150,7 @@
 				7DE0B51F2EECC49A00BDEB94 /* Borkle2.app */,
 				7DE0B5342EECC49B00BDEB94 /* Borkle2Tests.xctest */,
 				7D73FF142F2A755800590330 /* borkle1conv */,
+				7D7CF5F32F2EE9D300119BF9 /* borklekrunch */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -160,6 +186,29 @@
 			);
 			productName = borkle1conv;
 			productReference = 7D73FF142F2A755800590330 /* borkle1conv */;
+			productType = "com.apple.product-type.tool";
+		};
+		7D7CF5F22F2EE9D300119BF9 /* borklekrunch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7D7CF5F92F2EE9D300119BF9 /* Build configuration list for PBXNativeTarget "borklekrunch" */;
+			buildPhases = (
+				7D7CF5EF2F2EE9D300119BF9 /* Sources */,
+				7D7CF5F02F2EE9D300119BF9 /* Frameworks */,
+				7D7CF5F12F2EE9D300119BF9 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				7D7CF5F42F2EE9D300119BF9 /* borklekrunch */,
+			);
+			name = borklekrunch;
+			packageProductDependencies = (
+				7D7CF5FA2F2EEB2400119BF9 /* Yams */,
+			);
+			productName = borklekrunch;
+			productReference = 7D7CF5F32F2EE9D300119BF9 /* borklekrunch */;
 			productType = "com.apple.product-type.tool";
 		};
 		7DE0B51E2EECC49A00BDEB94 /* Borkle2 */ = {
@@ -221,6 +270,9 @@
 					7D73FF132F2A755800590330 = {
 						CreatedOnToolsVersion = 16.1;
 					};
+					7D7CF5F22F2EE9D300119BF9 = {
+						CreatedOnToolsVersion = 16.1;
+					};
 					7DE0B51E2EECC49A00BDEB94 = {
 						CreatedOnToolsVersion = 16.1;
 					};
@@ -250,6 +302,7 @@
 				7DE0B51E2EECC49A00BDEB94 /* Borkle2 */,
 				7DE0B5332EECC49B00BDEB94 /* Borkle2Tests */,
 				7D73FF132F2A755800590330 /* borkle1conv */,
+				7D7CF5F22F2EE9D300119BF9 /* borklekrunch */,
 			);
 		};
 /* End PBXProject section */
@@ -273,6 +326,13 @@
 
 /* Begin PBXSourcesBuildPhase section */
 		7D73FF102F2A755800590330 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7D7CF5EF2F2EE9D300119BF9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -316,6 +376,28 @@
 			name = Debug;
 		};
 		7D73FF1A2F2A755800590330 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2HBB3G8HCG;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		7D7CF5F72F2EE9D300119BF9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 2HBB3G8HCG;
+				ENABLE_HARDENED_RUNTIME = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		7D7CF5F82F2EE9D300119BF9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -548,6 +630,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		7D7CF5F92F2EE9D300119BF9 /* Build configuration list for PBXNativeTarget "borklekrunch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7D7CF5F72F2EE9D300119BF9 /* Debug */,
+				7D7CF5F82F2EE9D300119BF9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7DE0B51A2EECC49A00BDEB94 /* Build configuration list for PBXProject "Borkle2" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -590,6 +681,11 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		7D73FF212F2A89E500590330 /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7DE0B56B2EECF58900BDEB94 /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
+		};
+		7D7CF5FA2F2EEB2400119BF9 /* Yams */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7DE0B56B2EECF58900BDEB94 /* XCRemoteSwiftPackageReference "Yams" */;
 			productName = Yams;

--- a/platforms/apple/Borkle2/Borkle2.xcodeproj/xcshareddata/xcschemes/borklekrunch.xcscheme
+++ b/platforms/apple/Borkle2/Borkle2.xcodeproj/xcshareddata/xcschemes/borklekrunch.xcscheme
@@ -56,10 +56,6 @@
             argument = "/Users/markd/downloads/modcompnotes"
             isEnabled = "YES">
          </CommandLineArgument>
-         <CommandLineArgument
-            argument = "/Users/narkd/downloads/modcomp-krunch.txt"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/platforms/apple/Borkle2/Borkle2.xcodeproj/xcshareddata/xcschemes/borklekrunch.xcscheme
+++ b/platforms/apple/Borkle2/Borkle2.xcodeproj/xcshareddata/xcschemes/borklekrunch.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7D7CF5F22F2EE9D300119BF9"
+               BuildableName = "borklekrunch"
+               BlueprintName = "borklekrunch"
+               ReferencedContainer = "container:Borkle2.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D7CF5F22F2EE9D300119BF9"
+            BuildableName = "borklekrunch"
+            BlueprintName = "borklekrunch"
+            ReferencedContainer = "container:Borkle2.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "/Users/markd/downloads/modcompnotes"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/Users/narkd/downloads/modcomp-krunch.txt"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7D7CF5F22F2EE9D300119BF9"
+            BuildableName = "borklekrunch"
+            BlueprintName = "borklekrunch"
+            ReferencedContainer = "container:Borkle2.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/platforms/apple/Borkle2/Borkle2/Scene.swift
+++ b/platforms/apple/Borkle2/Borkle2/Scene.swift
@@ -5,6 +5,7 @@
 //    as internal tools
 
 import Foundation
+import AppKit
 
 class Scene: Codable {
 

--- a/platforms/apple/Borkle2/borklekrunch/main.swift
+++ b/platforms/apple/Borkle2/borklekrunch/main.swift
@@ -26,3 +26,57 @@ let soup = try! decoder.decode(BubbleSoup.self, from: soupData)
 let sceneData = try! Data(contentsOf: URL(fileURLWithPath: scenePath), options: [])
 let scene = try! decoder.decode(Scene.self, from: sceneData)
 
+// exhale in the exchange format, which is
+// 1
+// bubble-count
+// title (one line - we don't have any bodies or tags yet in the sample docs)
+// connection-count
+// bubble1ID bubble2ID (repeated for each connection)
+// geometry-count
+// bubbleID
+// bounds x y w h
+
+emitVersion()
+emitBubbles(soup)
+emitConnections(scene)
+emitGeometry(scene)
+emitTrailer()
+
+func emitVersion() {
+    print("1")
+}
+
+func flattenNewlines(_ string: String) -> String {
+    string.replacingOccurrences(of: "\n", with: "<NL>")
+}
+
+func emitBubbles(_ soup: BubbleSoup) {
+    let bubbles = soup.bubbles
+
+    print(bubbles.count)
+
+    for bubble in bubbles {
+        print(flattenNewlines(bubble.title ?? ""))
+    }
+}
+
+func emitConnections(_ scene: Scene) {
+    let connections = scene.connections
+    print(connections.count)
+    
+    for connection in connections {
+        print("\(connection.bubble1ID) \(connection.bubble2ID)")
+    }
+}
+
+func emitGeometry(_ scene: Scene) {
+    let geometries = scene.geometries
+    for geometry in geometries {
+        print(geometry.bubbleID)
+        print("\(Int(geometry.bounds.origin.x)) \(Int(geometry.bounds.origin.y)) \(Int(geometry.bounds.width)) \(Int(geometry.bounds.height))")
+    }
+}
+
+func emitTrailer() {
+    print("bork")
+}

--- a/platforms/apple/Borkle2/borklekrunch/main.swift
+++ b/platforms/apple/Borkle2/borklekrunch/main.swift
@@ -1,0 +1,18 @@
+// main.swift: driver for borklekrunch
+
+import Foundation
+import Yams
+
+let args = CommandLine.arguments
+
+// expecting two arguments
+guard args.count == 3 else {
+    print("Usage: \(args[0]) input-basename output-file")
+    print("    uses input-basename to derive bubble and a scene file name, then")
+    print("    exports an ascii output file suitable (hopefully) for older")
+    print("    systems")
+    exit(1)
+}
+
+print("splunge")
+

--- a/platforms/apple/Borkle2/borklekrunch/main.swift
+++ b/platforms/apple/Borkle2/borklekrunch/main.swift
@@ -6,13 +6,23 @@ import Yams
 let args = CommandLine.arguments
 
 // expecting two arguments
-guard args.count == 3 else {
-    print("Usage: \(args[0]) input-basename output-file")
+guard args.count == 2 else {
+    print("Usage: \(args[0]) input-basename")
     print("    uses input-basename to derive bubble and a scene file name, then")
-    print("    exports an ascii output file suitable (hopefully) for older")
+    print("    writes to stdout an ascii output file suitable (hopefully) for older")
     print("    systems")
     exit(1)
 }
 
-print("splunge")
+// load the bubbles and scene
+
+let bubblePath = "\(args[1])-bubbles.yaml"
+let scenePath = "\(args[1])-scene.yaml"
+let decoder = YAMLDecoder()
+
+let soupData = try! Data(contentsOf: URL(fileURLWithPath: bubblePath), options: [])
+let soup = try! decoder.decode(BubbleSoup.self, from: soupData)
+
+let sceneData = try! Data(contentsOf: URL(fileURLWithPath: scenePath), options: [])
+let scene = try! decoder.decode(Scene.self, from: sceneData)
 


### PR DESCRIPTION
One of the goals of Borkle2 is running documents on lesser-powered systems.
This PR adds a simple export format:

```
1
bubble-count
title (one line - we don't have any bodies or tags yet in the sample docs)
connection-count
bubble1ID bubble2ID (repeated for each connection)
geometry-count
bubbleID
bounds x y w h
bork
```

The current example file (modcomp-notes) originated from borkle1, and so doesn't have bodies or tags, so eliding them for this first version. Want to see what happens on the PERQ with a decent-sized yet not ridiculous-sized document.
