### PR TITLE
Adds mouse over support

### DIFF
--- a/platforms/apple/Borkle2/Borkle2/Bubble.swift
+++ b/platforms/apple/Borkle2/Borkle2/Bubble.swift
@@ -1,12 +1,14 @@
 import Foundation
 
+typealias BubbleID = Int32
 
 class Bubble : Codable {
+    static let illegalID: BubbleID = -1
 
     // Technically not needed, but handy for figuring out if we have
     // index issues.  This should match the array index in the bubble
     // soup.
-    var ID: Int32
+    var ID: BubbleID
 
     var title: String?
     var body: String?

--- a/platforms/apple/Borkle2/Borkle2/Colors.swift
+++ b/platforms/apple/Borkle2/Borkle2/Colors.swift
@@ -12,4 +12,6 @@ enum Colors {
     static let bubbleBackground = NSColor.white
     static let bubbleFrame = NSColor.black
     static let bubbleConnection = NSColor.purple
+
+    static let bubbleMouseOver = NSColor.orange.withAlphaComponent(0.1)
 }

--- a/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
@@ -37,12 +37,12 @@ class MouseMoved: MouseHandler {
         if let bubble = bubble {
             if lastBubbleID == nil || bubble.ID != lastBubbleID! {
                 lastBubbleID = bubble.ID
-                print("got a bubble \(bubble.title!)")
+                support.hoveredBubble(bubbleID: lastBubbleID)
             }
         } else {
             if lastBubbleID != nil {
                 lastBubbleID = nil
-                print("no bubble I")
+                support.hoveredBubble(bubbleID: lastBubbleID)
             }
         }
     }

--- a/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
@@ -14,13 +14,13 @@ class MouseMoved: MouseHandler {
     var moveThrottle: TimeInterval = 0.05
     var lastMoved: Date = Date()
 
-    var prefersWindowCoordinates: Bool { return true }
+    var prefersWindowCoordinates: Bool { return false }
     
     init(withSupport support: MouseSupport) {
         self.support = support
     }
 
-    func move(to: CGPoint, modifierFlags: NSEvent.ModifierFlags) {
+    func move(to point: CGPoint, modifierFlags: NSEvent.ModifierFlags) {
         let now = Date()
         let delta = now.timeIntervalSince(lastMoved)
 
@@ -29,12 +29,13 @@ class MouseMoved: MouseHandler {
         }
         lastMoved = now
 
-        print("move to \(to) flags \(modifierFlags)")
+        let bubble = support.hitTestBubble(at: point)
 
-        /*
-         let bubble = bubbleSoup.hitTestBubble(at: viewLocation)
-         highlightBubble(bubble)
-         */
+        if let bubble = bubble {
+            print("got a bubble \(bubble.title!)")
+        } else {
+            print("no bubble I")
+        }
     }
 }
 

--- a/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
@@ -1,0 +1,40 @@
+/// MouseMoved.swift - high-level handler for when the mouse gets moved
+/// in a view.
+
+import AppKit
+
+/// Currently, highlights the bubble the mouse is over.
+
+class MouseMoved: MouseHandler {
+    private var support: MouseSupport
+
+    /// We get absolutely hammered with mouse moved events, throttle
+    /// them down to a more reasonable rate.  We may lose some granular
+    /// movement, but I think this is an acceptable tradeoff
+    var moveThrottle: TimeInterval = 0.05
+    var lastMoved: Date = Date()
+
+    var prefersWindowCoordinates: Bool { return true }
+    
+    init(withSupport support: MouseSupport) {
+        self.support = support
+    }
+
+    func move(to: CGPoint, modifierFlags: NSEvent.ModifierFlags) {
+        let now = Date()
+        let delta = now.timeIntervalSince(lastMoved)
+
+        if delta < moveThrottle {
+            return
+        }
+        lastMoved = now
+
+        print("move to \(to) flags \(modifierFlags)")
+
+        /*
+         let bubble = bubbleSoup.hitTestBubble(at: viewLocation)
+         highlightBubble(bubble)
+         */
+    }
+}
+

--- a/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseMoved.swift
@@ -14,6 +14,9 @@ class MouseMoved: MouseHandler {
     var moveThrottle: TimeInterval = 0.05
     var lastMoved: Date = Date()
 
+    /// Don't retrigger on the same state.
+    var lastBubbleID: BubbleID? = Bubble.illegalID  // nil for no current bubble
+
     var prefersWindowCoordinates: Bool { return false }
     
     init(withSupport support: MouseSupport) {
@@ -32,9 +35,15 @@ class MouseMoved: MouseHandler {
         let bubble = support.hitTestBubble(at: point)
 
         if let bubble = bubble {
-            print("got a bubble \(bubble.title!)")
+            if lastBubbleID == nil || bubble.ID != lastBubbleID! {
+                lastBubbleID = bubble.ID
+                print("got a bubble \(bubble.title!)")
+            }
         } else {
-            print("no bubble I")
+            if lastBubbleID != nil {
+                lastBubbleID = nil
+                print("no bubble I")
+            }
         }
     }
 }

--- a/platforms/apple/Borkle2/Borkle2/MouseSupport.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseSupport.swift
@@ -17,7 +17,6 @@ extension MouseHandler {
     func drag(to: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
     func finish(at: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
     func move(to: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
-   
 }
 
 protocol MouseSupport {
@@ -25,6 +24,8 @@ protocol MouseSupport {
     func scroll(to: CGPoint)
 
     func hitTestBubble(at: CGPoint) -> Bubble?
+
+    func hoveredBubble(bubbleID: BubbleID?) // nil if over empty space
 
 /* FOR THE FUTURE
     func areaTestBubbles(intersecting: CGRect) -> [Bubble]?
@@ -41,6 +42,8 @@ protocol MouseSupport {
 
     func connect(bubbles: [Bubble], to: Bubble)
     func disconnect(bubbles: [Bubble], from: Bubble)
+
+    // renaming to "hoveredBubble"
     func highlightAsDropTarget(bubble: Bubble?) // nil to remove highlight
 
     func bubblesAffectedBy(barrier: Barrier) -> [Bubble]?
@@ -55,4 +58,6 @@ protocol MouseSupport {
 
 extension MouseHandler {
     var prefersWindowCoordinates: Bool { return false }
+
+    func hoveredBubble(bubbleID: BubbleID?) { }
 }

--- a/platforms/apple/Borkle2/Borkle2/MouseSupport.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseSupport.swift
@@ -24,8 +24,9 @@ protocol MouseSupport {
     var currentScrollOffset: CGPoint { get }
     func scroll(to: CGPoint)
 
-/* FOR THE FUTURE
     func hitTestBubble(at: CGPoint) -> Bubble?
+
+/* FOR THE FUTURE
     func areaTestBubbles(intersecting: CGRect) -> [Bubble]?
     func drawMarquee(around: CGRect)
 

--- a/platforms/apple/Borkle2/Borkle2/MouseSupport.swift
+++ b/platforms/apple/Borkle2/Borkle2/MouseSupport.swift
@@ -7,7 +7,17 @@ protocol MouseHandler {
     func drag(to: CGPoint, modifierFlags: NSEvent.ModifierFlags)
     func finish(at: CGPoint, modifierFlags: NSEvent.ModifierFlags)
 
+    func move(to: CGPoint, modifierFlags: NSEvent.ModifierFlags)
+
     var prefersWindowCoordinates: Bool { get }
+}
+
+extension MouseHandler {
+    func start(at: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
+    func drag(to: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
+    func finish(at: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
+    func move(to: CGPoint, modifierFlags: NSEvent.ModifierFlags) { }
+   
 }
 
 protocol MouseSupport {

--- a/platforms/apple/Borkle2/Borkle2/SceneView.swift
+++ b/platforms/apple/Borkle2/Borkle2/SceneView.swift
@@ -33,6 +33,21 @@ class SceneView: NSView {
     /// for things like "hey paste at the last place the user clicked.
     var lastPoint: CGPoint?
 
+
+    required init?(coder: NSCoder) {
+        currentCursor = .arrow
+        super.init(coder: coder)
+        addTrackingAreas()
+    }
+    
+    override init(frame: CGRect) {
+        currentCursor = .arrow
+        super.init(frame: frame)
+        addTrackingAreas()
+    }
+    var trackingArea: NSTrackingArea!
+
+
     func drawConnections() {
         Colors.bubbleConnection.set()
         for connection in scene.connections {
@@ -189,6 +204,37 @@ extension SceneView {
             return
         }
     }
+
+    override func updateTrackingAreas() {
+        if spaceDown { return }
+
+        if let trackingArea = trackingArea {
+            removeTrackingArea(trackingArea)
+            self.trackingArea = nil
+        }
+        addTrackingAreas()
+    }
+
+    func addTrackingAreas() {
+        let trackingArea = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow], owner: self, userInfo: nil)
+        addTrackingArea(trackingArea)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        if spaceDown { return }
+
+        let locationInWindow = event.locationInWindow
+        let viewLocation = convert(locationInWindow, from: nil)
+
+        Swift.print("WHEEEE! MOOSE MOVED \(Date())")
+
+        /*
+         let bubble = bubbleSoup.hitTestBubble(at: viewLocation)
+         highlightBubble(bubble)
+         */
+    }
+
+
 }
 
 extension SceneView: MouseSupport {

--- a/platforms/apple/Borkle2/Borkle2/SceneView.swift
+++ b/platforms/apple/Borkle2/Borkle2/SceneView.swift
@@ -3,6 +3,8 @@
 import AppKit
 
 class SceneView: NSView {
+    var lastMoved = Date()
+
     // eventually might want a scene stack, if scenes can reference other
     // scenes as bubbles
     var scene: Scene! {
@@ -26,6 +28,7 @@ class SceneView: NSView {
 
     // Event / user-interaction goodies
     var currentMouseHandler: MouseHandler?
+    var defaultMouseHandler: MouseHandler?
 
     var spaceDown: Bool = false
     var currentCursor: Cursor = .arrow
@@ -37,13 +40,17 @@ class SceneView: NSView {
     required init?(coder: NSCoder) {
         currentCursor = .arrow
         super.init(coder: coder)
+        defaultMouseHandler = MouseMoved(withSupport: self)
         addTrackingAreas()
+        currentMouseHandler = defaultMouseHandler
     }
     
     override init(frame: CGRect) {
         currentCursor = .arrow
         super.init(frame: frame)
+        defaultMouseHandler = MouseMoved(withSupport: self)
         addTrackingAreas()
+        currentMouseHandler = defaultMouseHandler
     }
     var trackingArea: NSTrackingArea!
 
@@ -192,7 +199,7 @@ extension SceneView {
         lastPoint = viewLocation
 
         defer {
-            currentMouseHandler = nil
+            currentMouseHandler = defaultMouseHandler
         }
 
         if spaceDown {
@@ -222,16 +229,18 @@ extension SceneView {
 
     override func mouseMoved(with event: NSEvent) {
         if spaceDown { return }
+        guard let handler = currentMouseHandler else { return} 
 
         let locationInWindow = event.locationInWindow
-        let viewLocation = convert(locationInWindow, from: nil)
 
-        Swift.print("WHEEEE! MOOSE MOVED \(Date())")
-
-        /*
-         let bubble = bubbleSoup.hitTestBubble(at: viewLocation)
-         highlightBubble(bubble)
-         */
+        if handler.prefersWindowCoordinates {
+            currentMouseHandler?.move(to: locationInWindow,
+                                      modifierFlags: event.modifierFlags)
+        } else {
+            let viewLocation = convert(locationInWindow, from: nil)
+            handler.move(to: viewLocation,
+                         modifierFlags: event.modifierFlags)
+        }
     }
 
 

--- a/platforms/apple/Borkle2/Borkle2/SceneView.swift
+++ b/platforms/apple/Borkle2/Borkle2/SceneView.swift
@@ -242,8 +242,6 @@ extension SceneView {
                          modifierFlags: event.modifierFlags)
         }
     }
-
-
 }
 
 extension SceneView: MouseSupport {
@@ -258,5 +256,18 @@ extension SceneView: MouseSupport {
 
     func scroll(to newOrigin: CGPoint) {
         scroll(newOrigin)
+    }
+
+    func hitTestBubble(at point: CGPoint) -> Bubble? {
+        guard let soup else { return nil }
+
+        for geometry in scene.geometries {
+            if geometry.bounds.contains(point) {
+                let bubbleID = geometry.bubbleID
+                let bubble = soup.bubbles[Int(bubbleID)]
+                return bubble
+            }
+        }
+        return nil
     }
 }

--- a/platforms/apple/Borkle2/Borkle2/SceneView.swift
+++ b/platforms/apple/Borkle2/Borkle2/SceneView.swift
@@ -33,6 +33,8 @@ class SceneView: NSView {
     var spaceDown: Bool = false
     var currentCursor: Cursor = .arrow
 
+    var highlightedBubbleID: BubbleID? = nil
+
     /// for things like "hey paste at the last place the user clicked.
     var lastPoint: CGPoint?
 
@@ -63,6 +65,13 @@ class SceneView: NSView {
         }
     }
 
+    func isBubbleMousedOver(_ id: BubbleID) -> Bool {
+        guard let highlightedBubbleID = highlightedBubbleID else {
+            return false
+        }
+        return id == highlightedBubbleID
+    }
+
     func drawBubbles() {
         NSColor.brown.set()
         for geometry in scene.geometries {
@@ -73,6 +82,13 @@ class SceneView: NSView {
 
             Colors.bubbleBackground.set()
             bezierPath.fill()
+
+            // right now highlighting bubbles by drawing a color wash
+            // over them.  So draw this over the prior background
+            if isBubbleMousedOver(geometry.bubbleID) {
+                Colors.bubbleMouseOver.set()
+                bezierPath.fill()
+            }
 
             let string = soup.bubbles[Int(geometry.bubbleID)].title! as NSString
 
@@ -273,10 +289,11 @@ extension SceneView: MouseSupport {
 
     func hoveredBubble(bubbleID: BubbleID?) {
         if let bubbleID = bubbleID {
-            let bubble = soup.bubbles[Int(bubbleID)]
-            print("got a bubble \(bubble.title!)")
+            highlightedBubbleID = bubbleID
+            needsDisplay = true
         } else {
-            print("no bubble I")
+            highlightedBubbleID = nil
+            needsDisplay = true
         }
     } // hoveredBubble
 }

--- a/platforms/apple/Borkle2/Borkle2/SceneView.swift
+++ b/platforms/apple/Borkle2/Borkle2/SceneView.swift
@@ -270,4 +270,13 @@ extension SceneView: MouseSupport {
         }
         return nil
     }
+
+    func hoveredBubble(bubbleID: BubbleID?) {
+        if let bubbleID = bubbleID {
+            let bubble = soup.bubbles[Int(bubbleID)]
+            print("got a bubble \(bubble.title!)")
+        } else {
+            print("no bubble I")
+        }
+    } // hoveredBubble
 }

--- a/worklog.md
+++ b/worklog.md
@@ -67,8 +67,27 @@ Hooking up the buttons is easy. Using an integer (e.g. 100, 120) for the zoom le
 makes it easy to look at and put into the UI, and not worry about floating point
 round-off (or maybe we can go all System Ten and BCD :all-the-things: %-) )
 
+==================================================
+# Thursday April 30, 2026
+
+do mouse-over bubble highlighting.
+
+Borkle 1 has a mouseMoved handler that hitessts the bubbles, and then
+highlights the found one.
 
 
+    func addTrackingAreas() {
+        let trackingArea = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow], owner: self, userInfo: nil)
+        addTrackingArea(trackingArea)
+    }
+
+but might be nice to have a mouse support thing for this - not click/drag,
+but just motion, rather than a specific canvas view method to do it.
+
+B1 has a highlightedID (optional) of the currently highlighted bubble (which
+implies just one highlighted bubble, which may be fine)
+
+B1 is kind of sluggish, and sometimes doesn't unhighlight
 
 
 

--- a/worklog.md
+++ b/worklog.md
@@ -89,6 +89,22 @@ implies just one highlighted bubble, which may be fine)
 
 B1 is kind of sluggish, and sometimes doesn't unhighlight
 
+==================================================
+# Wednesday May 20, 2026 - WiW
 
+oh yeah, had to reboot due to mac TCP/IP bug.
 
+where were we?  Seeing logs when changing to a bubble.
+That's coming from MouseMoved (So not getting surfaced back to say
+the scene view)
+
+It's doing a time throttle.  It should also do a content throttle,
+so it doesn't say "hey, we're over this bubble. WE'RE STILL OVER IT".
+Just do transitions.
+
+now plumbing it back.  Moose support had a `highlightAsDropTarget`.
+That's too specific. Call it 'hovered Bubble' for exactly what it is,
+the cursor is over a bubble, without any specific meaning
+
+and pass ID around rather than bubbles.
 


### PR DESCRIPTION
Before, waving the mouse over a scene view doesn't do anything.
This PR plumbs in support for reacting to mouse-moved, and draws an orange wash over bubbles that are moused over.

Continues expanding the mouse support stuff.


https://github.com/user-attachments/assets/d09c8469-aec6-4430-ab76-505d57f5f868

